### PR TITLE
EE-692: Use API error for upgrading contracts

### DIFF
--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -5,8 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::Error;
+use contract_ffi::contract_api::{self, Error};
 use contract_ffi::uref::URef;
 
 const ENTRY_FUNCTION_NAME: &str = "apply_method";
@@ -26,6 +25,7 @@ enum CallArgs {
     PurseHolderURef = 0,
 }
 
+#[repr(u16)]
 enum CustomError {
     MissingPurseHolderURefArg = 0,
     InvalidPurseHolderURefArg = 1,
@@ -37,13 +37,17 @@ enum CustomError {
     UnknownMethodName = 7,
 }
 
+impl From<CustomError> for Error {
+    fn from(error: CustomError) -> Self {
+        Error::User(error as u16)
+    }
+}
+
 fn purse_name() -> String {
     match contract_api::get_arg(ApplyArgs::PurseName as u32) {
         Some(Ok(data)) => data,
-        Some(Err(_)) => {
-            contract_api::revert(Error::User(CustomError::InvalidPurseNameArg as u16).into())
-        }
-        None => contract_api::revert(Error::User(CustomError::MissingPurseNameArg as u16).into()),
+        Some(Err(_)) => contract_api::revert_with_error(CustomError::InvalidPurseNameArg),
+        None => contract_api::revert_with_error(CustomError::MissingPurseNameArg),
     }
 }
 
@@ -51,10 +55,8 @@ fn purse_name() -> String {
 pub extern "C" fn apply_method() {
     let method_name: String = match contract_api::get_arg(ApplyArgs::MethodName as u32) {
         Some(Ok(data)) => data,
-        Some(Err(_)) => {
-            contract_api::revert(Error::User(CustomError::InvalidMethodNameArg as u16).into())
-        }
-        None => contract_api::revert(Error::User(CustomError::MissingMethodNameArg as u16).into()),
+        Some(Err(_)) => contract_api::revert_with_error(CustomError::InvalidMethodNameArg),
+        None => contract_api::revert_with_error(CustomError::MissingMethodNameArg),
     };
     match method_name.as_str() {
         METHOD_ADD => {
@@ -67,7 +69,7 @@ pub extern "C" fn apply_method() {
             contract_api::remove_uref(&purse_name);
         }
         METHOD_VERSION => contract_api::ret(&VERSION.to_string(), &vec![]),
-        _ => contract_api::revert(Error::User(CustomError::UnknownMethodName as u16).into()),
+        _ => contract_api::revert_with_error(CustomError::UnknownMethodName),
     }
 }
 
@@ -75,17 +77,12 @@ pub extern "C" fn apply_method() {
 pub extern "C" fn call() {
     let uref: URef = match contract_api::get_arg(CallArgs::PurseHolderURef as u32) {
         Some(Ok(data)) => data,
-        Some(Err(_)) => {
-            contract_api::revert(Error::User(CustomError::InvalidPurseHolderURefArg as u16).into())
-        }
-        None => {
-            contract_api::revert(Error::User(CustomError::MissingPurseHolderURefArg as u16).into())
-        }
+        Some(Err(_)) => contract_api::revert_with_error(CustomError::InvalidPurseHolderURefArg),
+        None => contract_api::revert_with_error(CustomError::MissingPurseHolderURefArg),
     };
 
-    let turef = contract_api::pointers::TURef::from_uref(uref).unwrap_or_else(|_| {
-        contract_api::revert(Error::User(CustomError::InvalidTURef as u16).into())
-    });
+    let turef = contract_api::pointers::TURef::from_uref(uref)
+        .unwrap_or_else(|_| contract_api::revert_with_error(CustomError::InvalidTURef));
 
     // this should overwrite the previous contract obj with the new contract obj at the same uref
     contract_api::upgrade_contract_at_uref(ENTRY_FUNCTION_NAME, turef);

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
 use contract_ffi::bytesrepr::{self, ToBytes};
+use contract_ffi::contract_api;
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, PurseId};
 use contract_ffi::value::{Value, U512};
@@ -425,7 +426,7 @@ where
                 // args(3) = size of name in Wasm memory
                 let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
                 let ret = self.upgrade_contract_at_uref(name_ptr, name_size, key_ptr, key_size)?;
-                Ok(Some(RuntimeValue::I32(ret.into())))
+                Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))
             }
         }
     }

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -11,7 +11,7 @@ use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef, Trap, TrapKind
 
 use contract_ffi::bytesrepr::{deserialize, ToBytes, U32_SIZE};
 use contract_ffi::contract_api::argsparser::ArgsParser;
-use contract_ffi::contract_api::{PurseTransferResult, TransferResult, UpgradeResult};
+use contract_ffi::contract_api::{Error as ApiError, PurseTransferResult, TransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::system_contracts::{self, mint};
 use contract_ffi::uref::{AccessRights, URef};
@@ -925,7 +925,7 @@ where
         name_size: u32,
         key_ptr: u32,
         key_size: u32,
-    ) -> Result<UpgradeResult, Trap> {
+    ) -> Result<Result<(), ApiError>, Trap> {
         let key = self.key_from_mem(key_ptr, key_size)?;
         let known_urefs = {
             match self.context.read_gs(&key)? {
@@ -947,8 +947,8 @@ where
             .context
             .upgrade_contract_at_uref(key, bytes, known_urefs)
         {
-            Ok(_) => Ok(UpgradeResult::Success),
-            Err(_) => Ok(UpgradeResult::UpgradeError),
+            Ok(_) => Ok(Ok(())),
+            Err(_) => Ok(Err(ApiError::UpgradeContractAtURef)),
         }
     }
 }


### PR DESCRIPTION
This is a suggested approach to avoid creating a new pseudo result type.

I'd like to see `revert()` replaced by the new `revert_with_error()` ultimately, but that will hit a lot of code.

I'm also not happy with the `result_from()` containing `unreachable!()`, but we have a few places where we reconstruct error/result types from integral values and these could maybe all do with being looked at (possibly writing a macro would be more robust).

I'm not sure whether it'd be better to have the revert called inside `contract_api::upgrade_contract_at_uref()` or to just pass the result back to the caller.  I _think_ it's better to handle the way I have, but maybe there's a use case where the user would be happy to ignore a failure there?