### PR TITLE
Replace fn_store_id with a deterministic rng.

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -192,6 +192,10 @@ where
         // Updated: random number generator is seeded from genesis_config_hash from the RunGenesis
         // RPC call
 
+        let fn_store_id = {
+            let generator = AddressGenerator::new(&genesis_config_hash.value(), phase);
+            Rc::new(RefCell::new(generator))
+        };
         let address_generator = {
             let generator = AddressGenerator::new(&genesis_config_hash.value(), phase);
             Rc::new(RefCell::new(generator))
@@ -206,6 +210,7 @@ where
             let authorization_keys: BTreeSet<PublicKey> = BTreeSet::new();
             let install_deploy_hash = genesis_config_hash.into();
             let address_generator = Rc::clone(&address_generator);
+            let fn_store_id = Rc::clone(&fn_store_id);
             let tracking_copy = Rc::clone(&tracking_copy);
             let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
 
@@ -227,6 +232,7 @@ where
                 phase,
                 ProtocolData::default(),
                 system_contract_cache,
+                fn_store_id,
             )?
         };
 
@@ -244,6 +250,7 @@ where
 
             let tracking_copy = Rc::clone(&tracking_copy);
             let address_generator = Rc::clone(&address_generator);
+            let fn_store_id = Rc::clone(&fn_store_id);
             let install_deploy_hash = genesis_config_hash.into();
             let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
 
@@ -286,6 +293,7 @@ where
                 phase,
                 partial_protocol_data,
                 system_contract_cache,
+                fn_store_id,
             )?
         };
 
@@ -319,6 +327,7 @@ where
             let authorization_keys = BTreeSet::new();
             let install_deploy_hash = genesis_config_hash.into();
             let address_generator = Rc::clone(&address_generator);
+            let fn_store_id = Rc::clone(&fn_store_id);
             let tracking_copy = Rc::clone(&tracking_copy);
             let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
 
@@ -340,6 +349,7 @@ where
                 phase,
                 protocol_data,
                 system_contract_cache,
+                fn_store_id,
             )?
         };
 
@@ -469,6 +479,7 @@ where
                         protocol_data,
                         system_contract_cache,
                         EntryPointType::Session,
+                        Rc::clone(&fn_store_id),
                     )?;
 
                     runtime
@@ -638,6 +649,10 @@ where
                     let generator = AddressGenerator::new(&pre_state_hash.value(), phase);
                     Rc::new(RefCell::new(generator))
                 };
+                let fn_store_id = {
+                    let generator = AddressGenerator::new(&pre_state_hash.value(), phase);
+                    Rc::new(RefCell::new(generator))
+                };
                 let state = Rc::clone(&tracking_copy);
                 let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
 
@@ -661,6 +676,7 @@ where
                     phase,
                     new_protocol_data,
                     system_contract_cache,
+                    fn_store_id,
                 )?
             }
         }
@@ -1319,6 +1335,7 @@ where
             if !self.config.use_system_contracts() && module_bytes_is_empty {
                 // let mut named_keys = account.named_keys().clone();
                 let address_generator = AddressGenerator::new(&deploy_hash, phase);
+                let fn_store_id = AddressGenerator::new(&deploy_hash, phase);
 
                 let mut runtime = match executor.create_runtime(
                     payment_module,
@@ -1338,6 +1355,7 @@ where
                     protocol_data,
                     system_contract_cache,
                     entry_point_type,
+                    Rc::new(RefCell::new(fn_store_id)),
                 ) {
                     Ok((_instance, runtime)) => runtime,
                     Err(error) => {

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -13,5 +13,3 @@ pub use self::{
 
 pub const MINT_NAME: &str = "mint";
 pub const POS_NAME: &str = "pos";
-
-pub(crate) const FN_STORE_ID_INITIAL: u32 = 0;

--- a/execution-engine/engine-test-support/src/internal/exec_with_return.rs
+++ b/execution-engine/engine-test-support/src/internal/exec_with_return.rs
@@ -21,8 +21,6 @@ use types::{
 
 use crate::internal::{utils, WasmTestBuilder, DEFAULT_WASM_COSTS};
 
-const INIT_FN_STORE_ID: u32 = 0;
-
 /// This function allows executing the contract stored in the given `wasm_file`, while capturing the
 /// output. It is essentially the same functionality as `Executor::exec`, but the return value of
 /// the contract is returned along with the effects. The purpose of this function is to test
@@ -63,7 +61,10 @@ where
         Rc::new(RefCell::new(address_generator))
     };
     let gas_counter = Gas::default();
-    let fn_store_id = INIT_FN_STORE_ID;
+    let fn_store_id = {
+        let fn_store_id = AddressGenerator::new(&deploy_hash, phase);
+        Rc::new(RefCell::new(fn_store_id))
+    };
     let gas_limit = Gas::new(U512::from(std::u64::MAX));
     let protocol_version = ProtocolVersion::V1_0_0;
     let correlation_id = CorrelationId::new();


### PR DESCRIPTION
This replaces completely the "seed" part of the new function address
generator with an unique, deterministic sequence that is always seeded
with deploy_hash and phase. This will produce unique and deterministic
values without global counter.

Co-authored-by: Ed Hastings <ed@casperlabs.io>

### Overview
_Provide a brief description of what this PR does, and why it's needed._

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
